### PR TITLE
demo issue with uniswap core & periphery using solc 0.8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,9 @@
 [submodule "lib/v3-periphery"]
 	path = lib/v3-periphery
 	url = https://github.com/uniswap/v3-periphery
+[submodule "lib/base64-sol"]
+	path = lib/base64-sol
+	url = https://github.com/Brechtpd/base64
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,6 @@
 # Full reference https://github.com/foundry-rs/foundry/tree/master/config
 
 [profile.default]
-  auto_detect_solc = false
   block_timestamp = 1_680_220_800 # March 31, 2023 at 00:00 GMT
   bytecode_hash = "none"
   cbor_metadata = false
@@ -13,7 +12,6 @@
   optimizer_runs = 10_000
   out = "out"
   script = "script"
-  solc = "0.8.19"
   src = "src"
   test = "test"
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,5 @@
 @prb/test/=lib/prb-test/src/
 forge-std/=lib/forge-std/src/
+@uniswap/v3-core/=lib/v3-core/
+@uniswap/v3-periphery/=lib/v3-periphery/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/

--- a/test/Uniswap.t.sol
+++ b/test/Uniswap.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+// If I try to compile using "pragma solidity >=0.8.19 <0.9.0;" I get the following compile error, hence why I am using "pragma solidity >=0.8.0;" instead.
+// Encountered invalid solc version in test/Uniswap.t.sol: Failed to parse solidity version >=0.8.19 <0.9.0: expected comma after patch version number, found '<'
+
+// However even after adjusting the solidity version as above described I still get the following compile error:
+// Discovered incompatible solidity versions in following
+// : test/Uniswap.t.sol (>=0.8.0) imports:
+//     lib/v3-core/contracts/UniswapV3Factory.sol (=0.8.12)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/NonfungibleTokenPositionDescriptor.sol (=0.8.15)
+//     lib/v3-periphery/contracts/NonfungiblePositionManager.sol (=0.8.15)
+//     lib/v3-periphery/contracts/SwapRouter.sol (=0.8.15)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Factory.sol (>=0.5.0)
+//     lib/v3-core/contracts/UniswapV3PoolDeployer.sol (=0.8.12)
+//     lib/v3-core/contracts/NoDelegateCall.sol (=0.8.12)
+//     lib/v3-core/contracts/UniswapV3Pool.sol (=0.8.12)
+//     lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolImmutables.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolState.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolActions.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolOwnerActions.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolErrors.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolEvents.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/SafeERC20Namer.sol (>=0.8.0)
+//     lib/v3-periphery/contracts/libraries/ChainId.sol (>=0.7.0)
+//     lib/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/INonfungibleTokenPositionDescriptor.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/interfaces/IERC20Metadata.sol (^0.8.0)
+//     lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/NFTDescriptor.sol (>=0.7.0)
+//     lib/v3-periphery/contracts/libraries/TokenRatioSortOrder.sol (^0.8.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/FixedPoint128.sol (>=0.4.0)
+//     lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
+//     lib/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/INonfungibleTokenPositionDescriptor.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/PositionKey.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/base/LiquidityManagement.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/Multicall.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/ERC721Permit.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/PeripheryValidation.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/SelfPermit.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/base/PoolInitializer.sol (=0.8.15)
+//     lib/v3-core/contracts/libraries/SafeCast.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/interfaces/ISwapRouter.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/PeripheryValidation.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/PeripheryPaymentsWithFee.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/base/Multicall.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/SelfPermit.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/Path.sol (>=0.6.0)
+//     lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/CallbackValidation.sol (^0.8.0)
+//     lib/v3-periphery/contracts/interfaces/external/IWETH9.sol (=0.8.15)
+//     lib/v3-core/contracts/interfaces/IUniswapV3PoolDeployer.sol (>=0.5.0)
+//     lib/v3-core/contracts/UniswapV3Pool.sol (=0.8.12)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
+//     lib/v3-core/contracts/NoDelegateCall.sol (=0.8.12)
+//     lib/v3-core/contracts/libraries/SafeCast.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/Tick.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/TickBitmap.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/Position.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/Oracle.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/FixedPoint128.sol (>=0.4.0)
+//     lib/v3-core/contracts/libraries/TransferHelper.sol (>=0.6.0)
+//     lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/SqrtPriceMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/SwapMath.sol (^0.8.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3PoolDeployer.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Factory.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/IERC20Minimal.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/callback/IUniswapV3MintCallback.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/callback/IUniswapV3FlashCallback.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/AddressStringUtil.sol (>=0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Metadata.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Enumerable.sol (^0.8.0)
+//     lib/v3-periphery/contracts/interfaces/IPoolInitializer.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/IERC721Permit.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/IPeripheryPayments.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol (>=0.7.5)
+//     lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/BitMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/utils/Strings.sol (^0.8.0)
+//     lib/base64-sol/base64.sol (>=0.6.0)
+//     lib/v3-periphery/contracts/libraries/HexStrings.sol (^0.8.0)
+//     lib/v3-periphery/contracts/libraries/NFTSVG.sol (>=0.7.6)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Factory.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/callback/IUniswapV3MintCallback.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
+//     lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/CallbackValidation.sol (^0.8.0)
+//     lib/v3-periphery/contracts/libraries/LiquidityAmounts.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/base/PeripheryPayments.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
+//     lib/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/interfaces/IMulticall.sol (>=0.7.5)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Enumerable.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/utils/Address.sol (^0.8.1)
+//     lib/v3-periphery/contracts/libraries/ChainId.sol (>=0.7.0)
+//     lib/v3-periphery/contracts/interfaces/external/IERC1271.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/interfaces/IERC721Permit.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/base/BlockTimestamp.sol (=0.8.15)
+//     lib/v3-periphery/contracts/base/BlockTimestamp.sol (=0.8.15)
+//     lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC20/extensions/draft-IERC20Permit.sol (^0.8.0)
+//     lib/v3-periphery/contracts/interfaces/ISelfPermit.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/external/IERC20PermitAllowed.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Factory.sol (>=0.5.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
+//     lib/v3-periphery/contracts/interfaces/IPoolInitializer.sol (>=0.7.5)
+//     lib/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol (>=0.5.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
+//     lib/v3-periphery/contracts/base/PeripheryPayments.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/IPeripheryPaymentsWithFee.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/external/IWETH9.sol (=0.8.15)
+//     lib/v3-periphery/contracts/libraries/TransferHelper.sol (>=0.6.0)
+//     lib/v3-periphery/contracts/libraries/BytesLib.sol (>=0.8.0 <0.9.0)
+//     lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
+//     lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/SafeCast.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/BitMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/FixedPoint128.sol (>=0.4.0)
+//     lib/v3-core/contracts/interfaces/IERC20Minimal.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/SafeCast.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/UnsafeMath.sol (>=0.5.0)
+//     lib/v3-core/contracts/libraries/FixedPoint96.sol (>=0.4.0)
+//     lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/SqrtPriceMath.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/utils/Strings.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/BitMath.sol (^0.8.0)
+//     lib/base64-sol/base64.sol (>=0.6.0)
+//     lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
+//     lib/v3-core/contracts/libraries/FixedPoint96.sol (>=0.4.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
+//     lib/v3-periphery/contracts/interfaces/IPeripheryPayments.sol (>=0.7.5)
+//     lib/v3-periphery/contracts/interfaces/external/IWETH9.sol (=0.8.15)
+//     lib/v3-periphery/contracts/libraries/TransferHelper.sol (>=0.6.0)
+//     lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/ERC721.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Enumerable.sol (^0.8.0)
+//     lib/v3-periphery/contracts/interfaces/IPeripheryPayments.sol (>=0.7.5)
+//     lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/utils/introspection/IERC165.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/IERC721Receiver.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Metadata.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/utils/Address.sol (^0.8.1)
+//     lib/openzeppelin-contracts/contracts/utils/Context.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/utils/Strings.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/utils/introspection/ERC165.sol (^0.8.0)
+//     lib/openzeppelin-contracts/contracts/utils/introspection/IERC165.sol (^0.8.0)
+
+// For context the following versions of the libs were installed:
+// uniswap/v3-core@0.8
+// uniswap/v3-periphery@0.8
+// openzeppelin/openzeppelin-contracts@release-v4.6
+
+import { UniswapV3Factory } from "@uniswap/v3-core/contracts/UniswapV3Factory.sol";
+import { IUniswapV3Pool } from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import { INonfungibleTokenPositionDescriptor } from "@uniswap/v3-periphery/contracts/NonfungibleTokenPositionDescriptor.sol";
+import { NonfungiblePositionManager } from "@uniswap/v3-periphery/contracts/NonfungiblePositionManager.sol";
+import { SwapRouter } from "@uniswap/v3-periphery/contracts/SwapRouter.sol";
+
+contract UniswapTest is PRBTest, StdCheats {
+
+    // Uniswap V3 contracts
+    UniswapV3Factory internal uniswapV3Factory;
+    NonfungibleTokenPositionDescriptor internal nonfungibleTokenPositionDescriptor;
+    NonfungiblePositionManager internal nonfungiblePositionManager;
+    SwapRouter internal swapRouter;
+
+    function setUp() public virtual {
+        uniswapV3Factory = new UniswapV3Factory();
+        nonfungibleTokenPositionDescriptor = new NonfungibleTokenPositionDescriptor(address(weth), "ETH");
+        nonfungiblePositionManager = new NonfungiblePositionManager(
+            address(uniswapV3Factory),
+            address(weth),
+            address(nonfungibleTokenPositionDescriptor)
+        );
+        swapRouter = new SwapRouter(address(uniswapV3Factory), address(weth));
+    }
+
+    function test_Uniswap() external {
+    }
+}


### PR DESCRIPTION
#### Description

This PR demonstrates the following 2 issues:
The 1st is when using `pragma solidity >=0.8.19 <0.9.0;`(or even `pragma solidity >=0.8.0 <0.9.0;`) in the test file(`Uniswap.t.sol`) that imports `uniswap/v3-core@0.8` and `uniswap/v3-periphery@0.8`, it fails to compile with the following error:
> Encountered invalid solc version in test/Uniswap.t.sol: Failed to parse solidity version >=0.8.19 <0.9.0: expected comma after patch version number, found '<'

The above issue is "fixed" by using `pragma solidity >=0.8.0;` instead, however this results in the 2nd issue; when trying to import `uniswap/v3-core@0.8` and `uniswap/v3-periphery@0.8` in the same test file(i.e. `Uniswap.t.sol`) I now get the following compiler error. As shown below the `uniswap/v3-core@0.8` contracts use solc 0.8.12 whereas the `uniswap/v3-periphery@0.8` contracts use solc 0.8.15. I want to be able to deploy both `v3-core@0.8` and `v3-periphery@0.8` contracts to my local foundry node.

```
Discovered incompatible solidity versions in following
: test/Uniswap.t.sol (>=0.8.0) imports:
    lib/v3-core/contracts/UniswapV3Factory.sol (=0.8.12)
    lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
    lib/v3-periphery/contracts/NonfungibleTokenPositionDescriptor.sol (=0.8.15)
    lib/v3-periphery/contracts/NonfungiblePositionManager.sol (=0.8.15)
    lib/v3-periphery/contracts/SwapRouter.sol (=0.8.15)
    lib/v3-core/contracts/interfaces/IUniswapV3Factory.sol (>=0.5.0)
    lib/v3-core/contracts/UniswapV3PoolDeployer.sol (=0.8.12)
    lib/v3-core/contracts/NoDelegateCall.sol (=0.8.12)
    lib/v3-core/contracts/UniswapV3Pool.sol (=0.8.12)
    lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolImmutables.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolState.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolDerivedState.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolActions.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolOwnerActions.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolErrors.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/pool/IUniswapV3PoolEvents.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/SafeERC20Namer.sol (>=0.8.0)
    lib/v3-periphery/contracts/libraries/ChainId.sol (>=0.7.0)
    lib/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/INonfungibleTokenPositionDescriptor.sol (>=0.5.0)
    lib/v3-periphery/contracts/interfaces/IERC20Metadata.sol (^0.8.0)
    lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/NFTDescriptor.sol (>=0.7.0)
    lib/v3-periphery/contracts/libraries/TokenRatioSortOrder.sol (^0.8.0)
    lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/FixedPoint128.sol (>=0.4.0)
    lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
    lib/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/INonfungibleTokenPositionDescriptor.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/PositionKey.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
    lib/v3-periphery/contracts/base/LiquidityManagement.sol (=0.8.15)
    lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
    lib/v3-periphery/contracts/base/Multicall.sol (=0.8.15)
    lib/v3-periphery/contracts/base/ERC721Permit.sol (=0.8.15)
    lib/v3-periphery/contracts/base/PeripheryValidation.sol (=0.8.15)
    lib/v3-periphery/contracts/base/SelfPermit.sol (>=0.5.0)
    lib/v3-periphery/contracts/base/PoolInitializer.sol (=0.8.15)
    lib/v3-core/contracts/libraries/SafeCast.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
    lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
    lib/v3-periphery/contracts/interfaces/ISwapRouter.sol (>=0.7.5)
    lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
    lib/v3-periphery/contracts/base/PeripheryValidation.sol (=0.8.15)
    lib/v3-periphery/contracts/base/PeripheryPaymentsWithFee.sol (>=0.7.5)
    lib/v3-periphery/contracts/base/Multicall.sol (=0.8.15)
    lib/v3-periphery/contracts/base/SelfPermit.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/Path.sol (>=0.6.0)
    lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/CallbackValidation.sol (^0.8.0)
    lib/v3-periphery/contracts/interfaces/external/IWETH9.sol (=0.8.15)
    lib/v3-core/contracts/interfaces/IUniswapV3PoolDeployer.sol (>=0.5.0)
    lib/v3-core/contracts/UniswapV3Pool.sol (=0.8.12)
    lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
    lib/v3-core/contracts/NoDelegateCall.sol (=0.8.12)
    lib/v3-core/contracts/libraries/SafeCast.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/Tick.sol (^0.8.0)
    lib/v3-core/contracts/libraries/TickBitmap.sol (^0.8.0)
    lib/v3-core/contracts/libraries/Position.sol (^0.8.0)
    lib/v3-core/contracts/libraries/Oracle.sol (^0.8.0)
    lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/FixedPoint128.sol (>=0.4.0)
    lib/v3-core/contracts/libraries/TransferHelper.sol (>=0.6.0)
    lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/SqrtPriceMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/SwapMath.sol (^0.8.0)
    lib/v3-core/contracts/interfaces/IUniswapV3PoolDeployer.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/IUniswapV3Factory.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/IERC20Minimal.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/callback/IUniswapV3MintCallback.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/callback/IUniswapV3FlashCallback.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/AddressStringUtil.sol (>=0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Metadata.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Enumerable.sol (^0.8.0)
    lib/v3-periphery/contracts/interfaces/IPoolInitializer.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/IERC721Permit.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/IPeripheryPayments.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
    lib/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol (>=0.7.5)
    lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
    lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/BitMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/utils/Strings.sol (^0.8.0)
    lib/base64-sol/base64.sol (>=0.6.0)
    lib/v3-periphery/contracts/libraries/HexStrings.sol (^0.8.0)
    lib/v3-periphery/contracts/libraries/NFTSVG.sol (>=0.7.6)
    lib/v3-core/contracts/interfaces/IUniswapV3Factory.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/callback/IUniswapV3MintCallback.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
    lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/CallbackValidation.sol (^0.8.0)
    lib/v3-periphery/contracts/libraries/LiquidityAmounts.sol (>=0.5.0)
    lib/v3-periphery/contracts/base/PeripheryPayments.sol (>=0.7.5)
    lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
    lib/v3-periphery/contracts/interfaces/IPeripheryImmutableState.sol (>=0.5.0)
    lib/v3-periphery/contracts/interfaces/IMulticall.sol (>=0.7.5)
    lib/openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Enumerable.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/utils/Address.sol (^0.8.1)
    lib/v3-periphery/contracts/libraries/ChainId.sol (>=0.7.0)
    lib/v3-periphery/contracts/interfaces/external/IERC1271.sol (>=0.5.0)
    lib/v3-periphery/contracts/interfaces/IERC721Permit.sol (>=0.7.5)
    lib/v3-periphery/contracts/base/BlockTimestamp.sol (=0.8.15)
    lib/v3-periphery/contracts/base/BlockTimestamp.sol (=0.8.15)
    lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC20/extensions/draft-IERC20Permit.sol (^0.8.0)
    lib/v3-periphery/contracts/interfaces/ISelfPermit.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/external/IERC20PermitAllowed.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/IUniswapV3Factory.sol (>=0.5.0)
    lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
    lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
    lib/v3-periphery/contracts/interfaces/IPoolInitializer.sol (>=0.7.5)
    lib/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol (>=0.5.0)
    lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
    lib/v3-periphery/contracts/base/PeripheryPayments.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/IPeripheryPaymentsWithFee.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/external/IWETH9.sol (=0.8.15)
    lib/v3-periphery/contracts/libraries/TransferHelper.sol (>=0.6.0)
    lib/v3-periphery/contracts/libraries/BytesLib.sol (>=0.8.0 <0.9.0)
    lib/v3-core/contracts/interfaces/IUniswapV3Pool.sol (>=0.5.0)
    lib/v3-periphery/contracts/libraries/PoolAddress.sol (>=0.5.0)
    lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
    lib/v3-core/contracts/libraries/SafeCast.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/TickMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/BitMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/FixedPoint128.sol (>=0.4.0)
    lib/v3-core/contracts/interfaces/IERC20Minimal.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/SafeCast.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/UnsafeMath.sol (>=0.5.0)
    lib/v3-core/contracts/libraries/FixedPoint96.sol (>=0.4.0)
    lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/SqrtPriceMath.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/utils/Strings.sol (^0.8.0)
    lib/v3-core/contracts/libraries/BitMath.sol (^0.8.0)
    lib/base64-sol/base64.sol (>=0.6.0)
    lib/v3-core/contracts/libraries/FullMath.sol (^0.8.0)
    lib/v3-core/contracts/libraries/FixedPoint96.sol (>=0.4.0)
    lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
    lib/v3-periphery/contracts/interfaces/IPeripheryPayments.sol (>=0.7.5)
    lib/v3-periphery/contracts/interfaces/external/IWETH9.sol (=0.8.15)
    lib/v3-periphery/contracts/libraries/TransferHelper.sol (>=0.6.0)
    lib/v3-periphery/contracts/base/PeripheryImmutableState.sol (=0.8.15)
    lib/openzeppelin-contracts/contracts/token/ERC721/ERC721.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Enumerable.sol (^0.8.0)
    lib/v3-periphery/contracts/interfaces/IPeripheryPayments.sol (>=0.7.5)
    lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/utils/introspection/IERC165.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/IERC721Receiver.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Metadata.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/utils/Address.sol (^0.8.1)
    lib/openzeppelin-contracts/contracts/utils/Context.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/utils/Strings.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/utils/introspection/ERC165.sol (^0.8.0)
    lib/openzeppelin-contracts/contracts/utils/introspection/IERC165.sol (^0.8.0)
```